### PR TITLE
Create Compare Time Zone (UTC and KST)

### DIFF
--- a/Gisellina/Gisellina/Services/TimeService.swift
+++ b/Gisellina/Gisellina/Services/TimeService.swift
@@ -3,14 +3,14 @@ import Foundation
 
 // MARK: - Supabase 응답을 받을 구조체
 struct UserMissionCreatedAt: Decodable {
-    let created_at: String?
+    let created_at: String
 }
 
 struct TimeService {
     // MARK: - created_at 시간 문자열 가져오기
     static func fetchLatestCreatedAt() async throws -> String {
         let client = SupabaseManager.shared.client
-        
+
         // Supabase에서 가장 최근 created_at 하나만 가져오기
         let result: [UserMissionCreatedAt] = try await client
             .from("map_user_mission_detail")
@@ -19,46 +19,163 @@ struct TimeService {
             .limit(1)
             .execute()
             .value
-        
+
         // 값이 없을 경우 에러
         guard let createdAt = result.first?.created_at else {
             throw NSError(domain: "No created_at found", code: 0)
         }
-        
+
         //  로그 출력화면
         print("📅 created_at:", createdAt)
         return createdAt
     }
-    
-    
-    // MARK: - UTC -> KST 문자열 변환 함수
+
+    // MARK: - UTC -> KST 문자열 변환 함수 (단순화된 버전)
     static func convertUTCToKST(from utcString: String) -> String? {
         print("🔵 [convertUTCToKST] 입력된 UTC 문자열:", utcString)
-        
-        let isoFormatter = ISO8601DateFormatter()
-        isoFormatter.formatOptions = [.withInternetDateTime]
-        isoFormatter.timeZone = TimeZone(secondsFromGMT: 0) // UTC
-        
-        guard let date = isoFormatter.date(from: utcString) else {
+
+        // ISO8601DateFormatter로 단순화
+        guard let date = parseUTCString(utcString) else {
             print("❌ [convertUTCToKST] 문자열을 Date로 변환 실패")
             return nil
         }
-        
+
         print("🟢 [convertUTCToKST] 변환된 Date 객체:", date)
-        
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
-        
-        let kstString = formatter.string(from: date)
+
+        // KST로 변환
+        let kstFormatter = DateFormatter()
+        kstFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        kstFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+
+        let kstString = kstFormatter.string(from: date)
         print("🟡 [convertUTCToKST] KST 변환된 문자열:", kstString)
-        
+
         return kstString
     }
-    
+
+    // MARK: - UTC 문자열을 Date 객체로 변환 (단순화된 파서)
+    private static func parseUTCString(_ utcString: String) -> Date? {
+        // 1. ISO8601DateFormatter 시도 (가장 표준적)
+        let iso8601Formatter = ISO8601DateFormatter()
+        iso8601Formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        if let date = iso8601Formatter.date(from: utcString) {
+            return date
+        }
+
+        // 2. 기본 ISO8601 (소수점 없이)
+        iso8601Formatter.formatOptions = [.withInternetDateTime]
+        if let date = iso8601Formatter.date(from: utcString) {
+            return date
+        }
+
+        // 3. 수동 포맷터 (Supabase 형식)
+        let manualFormatter = DateFormatter()
+        manualFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX"
+        if let date = manualFormatter.date(from: utcString) {
+            return date
+        }
+
+        return nil
+    }
+
+    // MARK: - 날짜 비교 함수 (같은 날짜인지 확인)
+    static func isSameDateAsToday(utcString: String) -> Bool {
+        print("📅 [isSameDateAsToday] UTC 문자열과 오늘 날짜 비교 시작: \(utcString)")
+
+        // UTC 문자열을 Date로 변환
+        guard let utcDate = parseUTCString(utcString) else {
+            print("❌ [isSameDateAsToday] UTC 문자열 파싱 실패")
+            return false
+        }
+
+        // 현재 시간 (기기의 로컬 시간)
+        let currentDate = Date()
+        print("🕐 [isSameDateAsToday] 현재 기기 로컬 시간:", currentDate)
+        print("🕐 [isSameDateAsToday] 파싱된 UTC Date 객체:", utcDate)
+
+        // 한국 시간대로 통일해서 비교
+        let calendar = Calendar.current
+        let kstTimeZone = TimeZone(identifier: "Asia/Seoul")!
+
+        // UTC 날짜를 KST로 변환하여 컴포넌트 추출
+        let utcComponents = calendar.dateComponents(in: kstTimeZone, from: utcDate)
+        // 현재 날짜를 KST로 변환하여 컴포넌트 추출
+        let currentComponents = calendar.dateComponents(in: kstTimeZone, from: currentDate)
+
+        let isSameDate = utcComponents.year == currentComponents.year &&
+                         utcComponents.month == currentComponents.month &&
+                         utcComponents.day == currentComponents.day
+
+        print("🟢 [isSameDateAsToday] UTC 날짜 (KST 기준): \(utcComponents.year ?? 0)-\(utcComponents.month ?? 0)-\(utcComponents.day ?? 0)")
+        print("🟢 [isSameDateAsToday] 현재 날짜 (KST 기준): \(currentComponents.year ?? 0)-\(currentComponents.month ?? 0)-\(currentComponents.day ?? 0)")
+        print("🔍 [isSameDateAsToday] 두 날짜는 같은 날인가요?: \(isSameDate)")
+
+        return isSameDate
+    }
+
+    // MARK: - 현재 Date()와 KST 문자열 비교
+    static func compareDateWithKST(kstString: String) -> Bool {
+        print("📅 [compareDateWithKST] KST 문자열과 현재 날짜 비교 시작: \(kstString)")
+
+        // KST 문자열을 Date로 변환
+        let kstFormatter = DateFormatter()
+        kstFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        kstFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+
+        guard let kstDate = kstFormatter.date(from: kstString) else {
+            print("❌ [compareDateWithKST] KST 문자열 파싱 실패")
+            return false
+        }
+
+        // 현재 시간
+        let currentDate = Date()
+        print("🕐 [compareDateWithKST] 현재 기기 로컬 시간:", currentDate)
+        print("🕐 [compareDateWithKST] 파싱된 KST Date 객체:", kstDate)
+
+        // 한국 시간대 기준으로 날짜 비교
+        let calendar = Calendar.current
+        let kstTimeZone = TimeZone(identifier: "Asia/Seoul")!
+
+        let kstComponents = calendar.dateComponents(in: kstTimeZone, from: kstDate)
+        let currentComponents = calendar.dateComponents(in: kstTimeZone, from: currentDate)
+
+        let isSameDate = kstComponents.year == currentComponents.year &&
+                         kstComponents.month == currentComponents.month &&
+                         kstComponents.day == currentComponents.day
+
+        print("🟢 [compareDateWithKST] 비교 대상 KST 날짜: \(kstComponents.year ?? 0)-\(kstComponents.month ?? 0)-\(kstComponents.day ?? 0)")
+        print("🟢 [compareDateWithKST] 현재 날짜 (KST 기준): \(currentComponents.year ?? 0)-\(currentComponents.month ?? 0)-\(currentComponents.day ?? 0)")
+        print("🔍 [compareDateWithKST] 두 날짜는 같은 날인가요?: \(isSameDate)")
+
+        return isSameDate
+    }
+
+    // MARK: - 현재 Date()와 임의의 Date 객체 비교 (보너스)
+    static func compareDates(_ date1: Date, with date2: Date) -> Bool {
+        print("📅 [compareDates] 두 Date 객체 비교 시작")
+        print("🕐 [compareDates] Date 1:", date1)
+        print("🕐 [compareDates] Date 2:", date2)
+
+        let calendar = Calendar.current
+        let kstTimeZone = TimeZone(identifier: "Asia/Seoul")!
+
+        let components1 = calendar.dateComponents(in: kstTimeZone, from: date1)
+        let components2 = calendar.dateComponents(in: kstTimeZone, from: date2)
+
+        let isSame = components1.year == components2.year &&
+                     components1.month == components2.month &&
+                     components1.day == components2.day
+
+        print("🟢 [compareDates] Date 1 (KST 기준): \(components1.year ?? 0)-\(components1.month ?? 0)-\(components1.day ?? 0)")
+        print("🟢 [compareDates] Date 2 (KST 기준): \(components2.year ?? 0)-\(components2.month ?? 0)-\(components2.day ?? 0)")
+        print("🔍 [compareDates] 두 날짜는 같은 날인가요?: \(isSame)")
+
+        return isSame
+    }
 }
 
-
+// MARK: - SwiftUI 뷰
 struct CreatedAtView: View {
     @State private var utcTime: String = ""
     @State private var kstTime: String = ""
@@ -66,35 +183,37 @@ struct CreatedAtView: View {
 
     var body: some View {
         VStack(spacing: 16) {
-            Text("Supabase 시간 (UTC):")
-            Text(utcTime).bold()
+            if errorMessage == nil {
+                Text("Supabase 시간 (UTC):")
+                Text(utcTime).bold()
 
-            Text("한국 시간 (KST):")
-            Text(kstTime).bold()
-
-            if let errorMessage = errorMessage {
+                Text("한국 시간 (KST):")
+                Text(kstTime).bold()
+            } else if let errorMessage = errorMessage {
                 Text("오류: \(errorMessage)")
                     .foregroundColor(.red)
+                    .padding()
             }
         }
         .padding()
+        // 3. .task 블록에서 일관된 에러 처리
         .task {
             do {
-                print("⏳ Supabase에서 created_at 값을 요청 중...")
-                let result = try await TimeService.fetchLatestCreatedAt()
-                print("✅ Supabase에서 받은 created_at:", result)
-                
-                utcTime = result
-                kstTime = TimeService.convertUTCToKST(from: result) ?? "변환 실패"
-                
+                let fetchedUtcTime = try await TimeService.fetchLatestCreatedAt()
+                self.utcTime = fetchedUtcTime
+                self.kstTime = try TimeService.convertUTCToKST(from: fetchedUtcTime) ?? ""
+
+                // Log the comparison results after fetching and converting
+                _ = TimeService.isSameDateAsToday(utcString: fetchedUtcTime)
+                _ = TimeService.compareDateWithKST(kstString: self.kstTime)
+
             } catch {
-                print("❗️에러 발생:", error.localizedDescription)
-                errorMessage = error.localizedDescription
+                // LocalizedError 프로토콜을 따르므로 errorDescription이 자동으로 사용됨
+                self.errorMessage = error.localizedDescription
             }
         }
     }
 }
-
 
 #Preview {
     CreatedAtView()

--- a/Gisellina/Gisellina/Views/TestView/SupaBaseTestView.swift
+++ b/Gisellina/Gisellina/Views/TestView/SupaBaseTestView.swift
@@ -189,10 +189,10 @@ struct SupabaseTestDetailView : View {
                         Text("🗂 유저 미션 완료 상태").font(.title2).bold()
                         ForEach(mapViewModel.mapUserMissionDetails) { item in
                             VStack(alignment: .leading) {
-                                Text("정답: \(item.answer)")
+                                Text("정답: \(String(describing: item.answer))")
                                 Text("획득 경험치: \(item.earned_exp)")
                                 Text("완료 여부: \(item.is_done ? "완료" : "미완료")")
-                                Text("시간: \(item.created_at)")
+                                Text("시간: \(String(describing: item.created_at))")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             }


### PR DESCRIPTION
# Pull Request: Feature/날짜-시간-처리-및-표시-기능-추가

---
### **상세 변경 내용**

#### 1. `UserMissionCreatedAt` 구조체 추가

* **목적**: Supabase에서 `created_at` 필드를 가져올 때, 해당 데이터가 Swift 코드에서 안전하고 쉽게 사용될 수 있도록 **명확한 데이터 형식**을 정의합니다.
* **변경 내용**:
    ```swift
    struct UserMissionCreatedAt: Decodable {
        let created_at: String
    }
    ```
* **설명**: Supabase에서 반환되는 JSON 데이터(예: `{"created_at": "2024-06-10T10:00:00Z"}`)를 Swift의 `UserMissionCreatedAt` 객체로 **자동 변환(디코딩)**할 수 있게 해주는 `Decodable` 프로토콜을 채택했습니다. 이는 데이터 처리 과정을 단순화하고 타입 오류를 방지하는 데 큰 도움이 됩니다.

#### 2. `TimeService` 구조체 (신규)

날짜 및 시간과 관련된 모든 복잡한 로직을 한 곳에 모아 **재사용성과 유지보수성**을 높이기 위해 `TimeService`라는 **정적(static) 유틸리티 구조체**를 새로 만들었습니다. 이 구조체의 모든 함수는 인스턴스를 생성할 필요 없이 `TimeService.함수이름()`처럼 직접 호출할 수 있습니다.

* **`fetchLatestCreatedAt() async throws -> String`**
    * **목적**: Supabase의 `map_user_mission_detail` 테이블에서 가장 최근에 생성된 `created_at` 타임스탬프 문자열을 **비동기적으로** 가져옵니다.
    * **세부 내용**:
        * `SupabaseManager.shared.client`를 사용해 데이터베이스와 통신합니다.
        * `created_at` 컬럼만 선택하고, 이 컬럼을 기준으로 내림차순 정렬(`ascending: false`)하여 가장 최신 데이터가 먼저 오도록 합니다.
        * `limit(1)`을 적용하여 단 하나의 최신 레코드만 가져옵니다.
        * 데이터가 없을 경우 `NSError`를 **던지도록(`throws`)** 하여 앱의 안정성을 높였습니다.
        * 디버깅을 돕기 위해 가져온 `created_at` 값을 콘솔에 `print`합니다.
* **`convertUTCToKST(from utcString: String) -> String?`**
    * **목적**: Supabase에서 가져온 **UTC 시간 문자열을 한국 표준시(KST) 문자열로 변환**합니다.
    * **세부 내용**:
        * `parseUTCString` 헬퍼 함수를 사용하여 UTC 문자열을 Swift의 `Date` 객체로 먼저 변환합니다.
        * `DateFormatter`를 사용하여 `yyyy-MM-dd HH:mm:ss` 형식으로 출력하되, **가장 중요한 `timeZone`을 "Asia/Seoul"로 설정**하여 UTC 시간을 KST로 정확히 보정합니다.
        * 변환 과정을 단계별로 콘솔에 `print`하여 흐름을 쉽게 파악할 수 있도록 했습니다.
* **`private static func parseUTCString(_ utcString: String) -> Date?`**
    * **목적**: 다양한 형태의 **ISO8601 기반 UTC 시간 문자열**을 `Date` 객체로 안정적으로 파싱하기 위한 **내부 헬퍼 함수**입니다.
    * **세부 내용**:
        * `ISO8601DateFormatter`를 사용하여 소수점 이하 초를 포함하거나 제외하는 표준 형식으로 파싱을 시도합니다.
        * 이후 Supabase에서 자주 사용되는 특정 포맷(`yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX`)을 위한 수동 `DateFormatter`를 사용하여 마지막으로 파싱을 시도합니다.
        * 어떤 시도도 성공하지 못하면 `nil`을 반환하여 변환 실패를 알립니다.
* **`isSameDateAsToday(utcString: String) -> Bool`**
    * **목적**: 주어진 UTC 날짜 문자열이 **오늘(현재 날짜)과 KST 기준으로 같은 날인지** 확인합니다.
    * **세부 내용**:
        * UTC 문자열을 `Date` 객체로 파싱하고, 현재 기기의 로컬 시간을 가져옵니다.
        * `Calendar.current`와 **`TimeZone(identifier: "Asia/Seoul")`**을 사용하여 두 날짜의 **연, 월, 일 컴포넌트를 KST 기준**으로 추출합니다. 이는 UTC 기준으로 날짜가 다르더라도 KST로는 같은 날일 수 있는 경우(예: UTC 어제 밤 11시가 KST 오늘 아침 8시)를 정확히 처리하기 위함입니다.
        * 두 날짜의 연, 월, 일이 모두 일치하는지 비교하여 `Bool` 값을 반환합니다.
        * 자세한 `print` 문을 통해 비교 과정을 추적할 수 있습니다.
* **`compareDateWithKST(kstString: String) -> Bool`**
    * **목적**: 이미 KST 형식으로 된 날짜 문자열이 **현재 날짜와 KST 기준으로 같은 날인지** 확인합니다.
    * **세부 내용**: `isSameDateAsToday`와 유사하게 작동하지만, 입력 문자열을 KST 형식으로 파싱하는 `DateFormatter`를 사용한다는 차이가 있습니다.
* **`compareDates(_ date1: Date, with date2: Date) -> Bool`**
    * **목적**: 임의의 두 `Date` 객체가 **KST 기준으로 같은 달력 날짜를 나타내는지** 확인하는 일반 유틸리티 함수입니다.
    * **세부 내용**: 두 `Date` 객체에서 KST 기준의 연, 월, 일 컴포넌트를 추출하여 비교합니다.

#### 3. `CreatedAtView` (SwiftUI 뷰)

* **목적**: `TimeService`를 통해 가져오고 변환된 시간 정보 및 날짜 비교 결과를 사용자에게 **시각적으로 표시**하고, 발생할 수 있는 **오류를 처리**합니다.
* **변경 내용**: `VStack`을 사용하여 UTC 시간과 KST 시간을 표시하는 간단한 UI를 구현했습니다.
* **상태 관리**:
    * `@State` 프로퍼티(`utcTime`, `kstTime`, `errorMessage`)를 사용하여 뷰의 데이터를 관리합니다. 이 변수들의 값이 변경되면 SwiftUI가 자동으로 UI를 업데이트합니다.
* **비동기 작업 (`.task` Modifier)**:
    * 뷰가 화면에 **나타날 때(`onAppear`와 유사)** 비동기 데이터 fetching (`fetchLatestCreatedAt`)을 수행하도록 `.task` 뷰 수정자를 사용했습니다. 이는 SwiftUI에서 비동기 작업을 처리하는 **권장 방식**입니다.
    * **오류 처리**: `do-catch` 블록을 `.task` 내부에 구현하여 Supabase 통신이나 시간 변환 중 발생할 수 있는 오류를 **안정적으로 처리**합니다. 오류가 발생하면 `errorMessage`가 설정되고, UI에 오류 메시지가 표시됩니다.
* **표시 로직**:
    * `errorMessage` 변수 값에 따라 시간 정보를 표시하거나(오류 없을 시), 오류 메시지를 표시(오류 발생 시)합니다.
* **비교 결과 로깅**: 시간을 성공적으로 가져오고 변환한 후, `isSameDateAsToday` 및 `compareDateWithKST` 함수를 호출하여 그 비교 결과를 직접 Xcode **콘솔에 로그로 출력**합니다. 반환 값은 UI에서 직접 사용되지 않으므로 `_ =`를 사용했습니다.

### **검토한 결과 출력 방법(view)모델**

1.  **`SupabaseManager` 설정 확인**: 이 PR에는 포함되지 않았지만, 앱에 설정된 `SupabaseManager`(`SupabaseManager.shared.client`를 통해 사용됨)가 Supabase 프로젝트에 올바르게 연결되어 있고, 데이터베이스 인증 정보가 유효한지 확인해주세요.
2.  **데이터 준비**: Supabase의 `map_user_mission_detail` 테이블에 최소 하나 이상의 항목이 존재하며, 유효한 `created_at` 타임스탬프가 포함되어 있는지 확인합니다.
3.  **앱 실행**:
    * Xcode에서 `CreatedAtView`의 SwiftUI **미리보기(Canvas)**를 실행하거나, 앱의 뷰 계층에 `CreatedAtView`를 통합하여 시뮬레이터나 실제 기기에서 실행합니다.
4.  **결과 확인**:
    * Xcode 콘솔에 출력되는 **로그 메시지**들을 면밀히 살펴보세요. UTC 시간, KST 변환 시간, 그리고 날짜 비교 결과(같은 날인지 여부)가 상세하게 출력될 것입니다.
    * 앱 화면에 표시되는 UTC 시간과 KST 시간이 올바른지, 특히 KST 변환이 현재 한국 시간대를 정확하게 반영하는지 확인하세요.
    * 로그를 통해 날짜 비교 결과가 예상대로(`isSameDateAsToday` 함수가 '오늘'과 일치하는지) 올바르게 작동하는지 검증합니다.
