### PR TITLE
[Update] Design = TimeService and CreateAnswerView, Study Mission Compl…

### DIFF
--- a/Gisellina/Gisellina/Services/TimeService.swift
+++ b/Gisellina/Gisellina/Services/TimeService.swift
@@ -174,47 +174,47 @@ struct TimeService {
         return isSame
     }
 }
-
-// MARK: - SwiftUI 뷰
-struct CreatedAtView: View {
-    @State private var utcTime: String = ""
-    @State private var kstTime: String = ""
-    @State private var errorMessage: String?
-
-    var body: some View {
-        VStack(spacing: 16) {
-            if errorMessage == nil {
-                Text("Supabase 시간 (UTC):")
-                Text(utcTime).bold()
-
-                Text("한국 시간 (KST):")
-                Text(kstTime).bold()
-            } else if let errorMessage = errorMessage {
-                Text("오류: \(errorMessage)")
-                    .foregroundColor(.red)
-                    .padding()
-            }
-        }
-        .padding()
-        // 3. .task 블록에서 일관된 에러 처리
-        .task {
-            do {
-                let fetchedUtcTime = try await TimeService.fetchLatestCreatedAt()
-                self.utcTime = fetchedUtcTime
-                self.kstTime = try TimeService.convertUTCToKST(from: fetchedUtcTime) ?? ""
-
-                // Log the comparison results after fetching and converting
-                _ = TimeService.isSameDateAsToday(utcString: fetchedUtcTime)
-                _ = TimeService.compareDateWithKST(kstString: self.kstTime)
-
-            } catch {
-                // LocalizedError 프로토콜을 따르므로 errorDescription이 자동으로 사용됨
-                self.errorMessage = error.localizedDescription
-            }
-        }
-    }
-}
-
-#Preview {
-    CreatedAtView()
-}
+//
+//// MARK: - SwiftUI 뷰
+//struct CreatedAtView: View {
+//    @State private var utcTime: String = ""
+//    @State private var kstTime: String = ""
+//    @State private var errorMessage: String?
+//
+//    var body: some View {
+//        VStack(spacing: 16) {
+//            if errorMessage == nil {
+//                Text("Supabase 시간 (UTC):")
+//                Text(utcTime).bold()
+//
+//                Text("한국 시간 (KST):")
+//                Text(kstTime).bold()
+//            } else if let errorMessage = errorMessage {
+//                Text("오류: \(errorMessage)")
+//                    .foregroundColor(.red)
+//                    .padding()
+//            }
+//        }
+//        .padding()
+//        // 3. .task 블록에서 일관된 에러 처리
+//        .task {
+//            do {
+//                let fetchedUtcTime = try await TimeService.fetchLatestCreatedAt()
+//                self.utcTime = fetchedUtcTime
+//                self.kstTime = try TimeService.convertUTCToKST(from: fetchedUtcTime) ?? ""
+//
+//                // Log the comparison results after fetching and converting
+//                _ = TimeService.isSameDateAsToday(utcString: fetchedUtcTime)
+//                _ = TimeService.compareDateWithKST(kstString: self.kstTime)
+//
+//            } catch {
+//                // LocalizedError 프로토콜을 따르므로 errorDescription이 자동으로 사용됨
+//                self.errorMessage = error.localizedDescription
+//            }
+//        }
+//    }
+//}
+//
+//#Preview {
+//    CreatedAtView()
+//}

--- a/Gisellina/Gisellina/Views/StudyMissionView/CreateAnswerView.swift
+++ b/Gisellina/Gisellina/Views/StudyMissionView/CreateAnswerView.swift
@@ -1,72 +1,82 @@
 import SwiftUI
-
+import Foundation
+import Supabase
 
 struct CreateAnswerView: View {
-    @State private var writeANswerText: String = ""
+
+    @State private var content: String = "" // 사용자가 입력할 답변 내용
     @State private var keyboardHeight: CGFloat = 0
     @FocusState private var isTextEditorFocused: Bool
-    
+
+    @State private var isLoading: Bool = false
+    @State private var statusMessage: String = ""
+    @State private var showAlert: Bool = false
+    @State private var isSubmitted: Bool = false
+
+    // 미션 ID - 직접 설정하거나 다른 방식으로 받아올 수 있습니다
+    @State private var currentMissionID: UUID?
     @EnvironmentObject var router: Router
-    
+
     //MARK: - Safe Area Top을 설정합니다.
-    
     var safeAreaTop: CGFloat {
-            UIApplication.shared.connectedScenes
-                .compactMap { ($0 as? UIWindowScene)?.windows.first?.safeAreaInsets.top }
-                .first ?? 20 // 기본값 20 (예: iPhone SE)
-        }
-    
-    
+        UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.windows.first?.safeAreaInsets.top }
+            .first ?? 20 // 기본값 20 (예: iPhone SE)
+    }
+
     //MARK: - View Start
     var body: some View {
         ZStack {
             Image("ExerciseMissionView_background")
                 .resizable()
                 .ignoresSafeArea(edges: .all)
-            
+
+        ZStack {
+            Image("ExerciseMissionView_background")
+                .resizable()
+                .ignoresSafeArea(edges: .all)
+
             VStack(spacing: 12){
-                
+
                 //MARK: - Top Navigation Menu Bar(look like Noah View)
                 CustomNavigationBar(
                     title: "사건 검토하기",
-                    titleColor: .white,    // ← 제목 텍스트 색상
+                    titleColor: .white,
                     leftItem: AnyView(
                         NavigationIconButton(
                             action: { router.pop() },
                             iconName: "chevron.left",
-                            iconColor: .white     // ← 아이콘 색상
+                            iconColor: .white
                         )
                     )
                 )
-                
-                
+
                 VStack{
                     Image("MissionCharacter")
                 }
                 .frame(maxWidth: .infinity)
-                
-                
+
                 Text("답변을 작성해 보세요")
                     .font(.title2)
                     .fontWeight(.semibold)
-                
+
                 Text("관련 법령, 판례, 논리를 바탕으로 사례를 분석해 보세요.")
                     .font(.callout)
                     .padding(.bottom)
-                
+
                 ZStack(alignment: .topLeading) {
                     RoundedRectangle(cornerRadius: 12)
                         .fill(Color.gray.opacity(0.1))
-                    
+
                     // Placeholder
-                    if writeANswerText.isEmpty {
+                    if content.isEmpty {
                         Text("관련 법령, 판례, 논리를 바탕으로 사건을 검토해주세요.")
                             .font(.caption)
                             .foregroundColor(.gray)
                             .padding(12)
                     }
-                    
-                    TextEditor(text: $writeANswerText)
+
+                    TextEditor(text: $content)
                         .font(.caption)
                         .padding(8)
                         .scrollContentBackground(.hidden)
@@ -74,24 +84,184 @@ struct CreateAnswerView: View {
                         .focused($isTextEditorFocused)
                 }
                 .frame(height: 252)
-                
-                NavigationLink(destination: {
-                    StudyMissionCompleteView()
-                }, label: {
-                    Text("제출하기")
-                        .frame(width: 240, height: 50)
-                        .foregroundStyle(.white)
-                        .background(Color(red: 0, green: 0.58, blue: 0.9))
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                })
+
+                Button {
+                    Task {
+                        await submitAnswer()
+                    }
+                } label: {
+                    if isLoading {
+                        HStack {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                .scaleEffect(0.8)
+                            Text("제출 중...")
+                                .foregroundStyle(.white)
+                        }
+                    } else {
+                        Text("제출하기")
+                            .foregroundStyle(.white)
+                    }
+                }
+                .frame(width: 240, height: 50)
+                .background(
+                    Color(red: 0, green: 0.58, blue: 0.9)
+                        .opacity(isLoading || !isFormValid() ? 0.6 : 1.0)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .disabled(isLoading || !isFormValid())
+
+                // 새로운 방식 (iOS 16+)
+                .navigationDestination(isPresented: $isSubmitted) {
+                    StudyMissionCompleteView(currentMissionID: currentMissionID ?? UUID())
+                }
             }
             .padding(.horizontal, 24)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
+        }
+        .onAppear {
+            // 필요시 미션 ID를 설정하는 로직을 여기에 추가
+            // 예: currentMissionID = UUID() // 임시로 새 UUID 생성
+            getCurrentMissionID()
+        }
+        .alert(isPresented: $showAlert) {
+            Alert(title: Text("알림"), message: Text(statusMessage), dismissButton: .default(Text("확인")))
+        }
         .navigationBarBackButtonHidden(true)
     }
-}
 
-#Preview {
-    CreateAnswerView()
+    // 현재 미션 ID 가져오기 - Supabase에서 데이터 확인
+    private func getCurrentMissionID() {
+        Task {
+            await fetchMissionFromSupabase()
+        }
+    }
+    
+    @MainActor
+    private func fetchMissionFromSupabase() async {
+        // print("🔍 Supabase에서 미션 데이터 확인 시작")
+        
+        do {
+            // 1. 먼저 테이블에 어떤 데이터가 있는지 확인
+            let response = try await SupabaseManager.shared.client
+                .from("map_user_mission_detail")
+                .select("*")
+                .limit(5) // 최대 5개만 가져와서 확인
+                .execute()
+            
+            // print("📊 Supabase 응답 데이터:")
+            // if let jsonString = String(data: response.data, encoding: .utf8) {
+            //     print(jsonString)
+            // } else {
+            //     print("❌ 응답 데이터를 문자열로 변환할 수 없음")
+            // }
+            
+            // 2. JSON을 Dictionary 배열로 파싱해서 확인
+            if let jsonArray = try JSONSerialization.jsonObject(with: response.data) as? [[String: Any]] {
+                // print("📝 파싱된 데이터 개수: \(jsonArray.count)")
+                
+                // for (index, item) in jsonArray.enumerated() {
+                //     print("--- 항목 \(index + 1) ---")
+                //     for (key, value) in item {
+                //         print("\(key): \(value)")
+                //     }
+                // }
+                
+                // 3. 첫 번째 항목에서 ID 찾기
+                if let firstItem = jsonArray.first {
+                    // 가능한 ID 필드명들을 확인
+                    let possibleIdKeys = ["id", "user_detail_id", "mission_id", "detail_id"]
+                    
+                    for key in possibleIdKeys {
+                        if let idValue = firstItem[key] {
+                            // print("🎯 찾은 ID 필드: \(key) = \(idValue)")
+                            
+                            // UUID로 변환 시도
+                            if let idString = idValue as? String, let uuid = UUID(uuidString: idString) {
+                                currentMissionID = uuid
+                                print("✅ 미션 ID 설정 성공: \(uuid)")
+                                return
+                            }
+                        }
+                    }
+                    
+                    // print("⚠️ UUID 필드를 찾을 수 없음. 사용 가능한 필드:")
+                    // for key in firstItem.keys {
+                    //     print("- \(key)")
+                    // }
+                }
+            }
+            
+        } catch {
+            print("❌ Supabase 데이터 가져오기 실패: \(error)")
+            statusMessage = "데이터를 가져올 수 없습니다: \(error.localizedDescription)"
+            showAlert = true
+        }
+    }
+
+    // 유효성 검사
+    private func isFormValid() -> Bool {
+        !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // 초기화
+    private func resetForm() {
+        content = ""
+        statusMessage = ""
+        showAlert = false
+    }
+
+    // 답변 제출
+    @MainActor
+    private func submitAnswer() async {
+        // print("🚀 답변 제출 시작")
+
+        guard let currentDetailID: UUID = currentMissionID else {
+            statusMessage = "미션 ID가 설정되지 않았습니다."
+            showAlert = true
+            return
+        }
+
+        // print("🧩 currentDetailID: \(currentDetailID)")
+        // print("📝 입력된 답변: \(content)")
+
+        guard isFormValid() else {
+            statusMessage = "답변 내용을 입력해주세요."
+            showAlert = true
+            return
+        }
+
+        isLoading = true
+
+        do {
+            let updateData: [String: AnyJSON] = [
+                "answer": AnyJSON.string(content.trimmingCharacters(in: .whitespacesAndNewlines)),
+                "earned_exp": AnyJSON(10),
+                "is_done": AnyJSON.bool(true)
+            ]
+
+            // print("📦 업데이트할 데이터: \(updateData)")
+
+            let response = try await SupabaseManager.shared.client
+                .from("map_user_mission_detail")
+                .update(updateData)
+                .eq("user_detail_id", value: currentDetailID)
+                .execute()
+
+            print("✅ 업데이트 성공: \(String(data: response.data, encoding: .utf8) ?? "데이터 없음")")
+
+            statusMessage = "답변이 성공적으로 제출되었습니다!"
+            showAlert = false
+            isSubmitted = true
+            resetForm()
+
+        } catch {
+            print("❌ 제출 실패: \(error)")
+            statusMessage = "답변 제출 실패: \(error.localizedDescription)"
+            showAlert = true
+        }
+
+        isLoading = false
+    }
 }

--- a/Gisellina/Gisellina/Views/StudyMissionView/StudyMissionCompleteView.swift
+++ b/Gisellina/Gisellina/Views/StudyMissionView/StudyMissionCompleteView.swift
@@ -1,10 +1,15 @@
+import Foundation
 import SwiftUI
+
 
 struct StudyMissionCompleteView : View {
     @EnvironmentObject var router: Router  // 라우터 환경객체
-    
+    @State private var answer: String? = nil
+    @State private var detailCase: String? = nil
     @State private var scrollOffset: CGFloat = 0
     private let screenWidth = UIScreen.main.bounds.width
+    
+    let currentMissionID: UUID?
     
     //MARK: - Safe Area Top을 설정합니다.
     
@@ -16,7 +21,9 @@ struct StudyMissionCompleteView : View {
     
     
     var body : some View{
-        ZStack {
+
+        // 로그 출력
+         ZStack {
             Image("ExerciseMissionView_background")
                 .resizable()
                 .ignoresSafeArea(edges: .all)
@@ -44,12 +51,9 @@ struct StudyMissionCompleteView : View {
                             .multilineTextAlignment(.center)
                             
                             ScrollView {
-                                Text("""
-                                    Contrary to popular belief, Lorem Ipsum is not simply random text.Contrary to popular belief, Lorem Ipsum is not simply random
-                                    """)
-                                .font(.body)
-                                .padding(.horizontal)
-                                
+                                Text(detailCase ?? "모범답안이 없습니다.")
+                                    .font(.body)
+                                    .padding(.horizontal)
                             }
                             .scrollIndicators(.hidden)
                         }
@@ -74,10 +78,8 @@ struct StudyMissionCompleteView : View {
                             .multilineTextAlignment(.center)
                             
                             ScrollView {
-                                Text("""
-                                    Contrary to popular belief, Lorem Ipsum is not simply random text.Contrary to popular belief, Lorem Ipsum is not simply random
-                                    """)
-                                .font(.body)
+                                Text(answer ?? "답변이 없습니다.")
+                                    .font(.body)
                             }
                             .scrollIndicators(.hidden)
                         }
@@ -116,10 +118,101 @@ struct StudyMissionCompleteView : View {
                 Spacer()
             }
             .navigationBarBackButtonHidden(true)
+            .onAppear {
+                print("🟡 전달받은 currentMissionID: \(String(describing: currentMissionID))")
+                Task {
+                    do {
+                        if let missionID = currentMissionID {
+                            print("🟢 Supabase 쿼리에 사용된 missionID: \(missionID)")
+                            if let info = try await StudyCompleteService.fetchStudyComplete(missionID: missionID) {
+                                self.answer = info.answer
+
+                                if let detailID = info.detail_id {
+                                    if let missionDetail = try await StudyCompleteService.fetchMissionDetail(detailID: detailID) {
+                                        self.detailCase = missionDetail.detail_answer
+                                    }
+                                }
+                            }
+                        }
+                    } catch {
+                        print("❌ 답변 불러오기 실패:", error)
+                    }
+                }
+            }
         }
     }
 }
 
+//MARK: - Study Complete Model
+
+struct UserAnswerInfo: Decodable {
+    let answer: String?
+    let detail_id: UUID?
+}
+
+struct MissionDetailModel: Decodable {
+    let detail_answer: String?
+}
+
+//MARK: - Study CompleteService
+
+struct StudyCompleteService {
+    /// 완료된 study 미션의 답변과 detail_id를 모두 가져옵니다.
+    static func fetchStudyComplete(missionID: UUID) async throws -> UserAnswerInfo? {
+        let client = SupabaseManager.shared.client
+
+        let results: [UserAnswerInfo] = try await client
+            .from("map_user_mission_detail")
+            .select("answer, detail_id")
+            .eq("user_detail_id", value: missionID)
+            .limit(1)
+            .execute()
+            .value
+
+        return results.first
+    }
+    
+    static func fetchMissionDetail(detailID: UUID) async throws -> MissionDetailModel? {
+        let client = SupabaseManager.shared.client
+
+        let results: [MissionDetailModel] = try await client
+            .from("mission_details")
+            .select("detail_answer")
+            .eq("detail_id", value: detailID)
+            .limit(1)
+            .execute()
+            .value
+
+        return results.first
+    }
+}
+
+struct StudyCompleteModel: Identifiable, Codable, Equatable, Hashable {
+    let user_detail_id: UUID          // PK
+    let created_at: String?           // ISO8601 형식
+    let earned_exp: Int?              // int8
+    let answer: String?               // 사용자의 답변
+    let user_id: UUID                 // 사용자 ID
+    let detail_id: UUID               // 미션 상세 ID (FK)
+    let is_done: Bool                 // 완료 여부
+
+    enum CodingKeys: String, CodingKey {
+        case user_detail_id = "user_detail_id"
+        case created_at = "created_at"
+        case earned_exp = "earned_exp"
+        case answer = "answer"
+        case user_id = "user_id"
+        case detail_id = "detail_id"
+        case is_done = "is_done"
+    }
+
+    var id: UUID { user_detail_id }
+}
+
+
+
+
+
 #Preview {
-    StudyMissionCompleteView()
+    StudyMissionCompleteView(currentMissionID: UUID())
 }

--- a/Gisellina/Gisellina/Views/TestView/FormTextPostView.swift
+++ b/Gisellina/Gisellina/Views/TestView/FormTextPostView.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+import Foundation
+import Supabase
+
+struct FormTextPostView: View {
+    // 폼 데이터 상태
+    @State private var content: String = "" // 사용자가 입력할 답변 내용
+
+    // 미션 상태
+    @State private var todayStudyMission: StudyMissionDetail?
+
+    // UI 상태
+    @State private var isLoading: Bool = false
+    @State private var statusMessage: String = ""
+    @State private var showAlert: Bool = false
+
+    // 외부에서 주입받아야 할 값들
+    let currentUserID: UUID
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+
+                // ✅ 오늘의 미션 표시
+                if let mission = todayStudyMission {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("📝 오늘의 미션 내용:")
+                            .font(.headline)
+                        Text(mission.body)
+                            .padding(8)
+                            .background(Color(.systemGray5))
+                            .cornerRadius(8)
+                    }
+                    .padding(.horizontal)
+                }
+
+                // 폼 헤더
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("미션 답변 제출")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+
+                    Text("여기에 미션에 대한 답변을 작성하고 제출해주세요.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal)
+
+                // 답변 입력
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("답변 내용 *")
+                        .font(.headline)
+
+                    TextEditor(text: $content)
+                        .frame(minHeight: 150)
+                        .padding(8)
+                        .background(Color(.systemGray6))
+                        .cornerRadius(8)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color(.systemGray4), lineWidth: 1)
+                        )
+                }
+                .padding(.horizontal)
+
+                // 제출 버튼
+                Button(action: {
+                    Task {
+                        await submitAnswer()
+                    }
+                }) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        }
+                        Text(isLoading ? "전송 중..." : "답변 제출")
+                            .fontWeight(.semibold)
+                    }
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isFormValid() ? Color.blue : Color.gray)
+                    .cornerRadius(10)
+                }
+                .disabled(!isFormValid() || isLoading)
+                .padding(.horizontal)
+
+                // 초기화 버튼
+                Button(action: resetForm) {
+                    Text("초기화")
+                        .foregroundColor(.red)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color(.systemGray6))
+                        .cornerRadius(10)
+                }
+                .disabled(isLoading)
+                .padding(.horizontal)
+
+                Spacer()
+            }
+            .padding(.top, 20)
+            .navigationBarHidden(true)
+        }
+        .alert("알림", isPresented: $showAlert) {
+            Button("확인", role: .cancel) { }
+        } message: {
+            Text(statusMessage)
+        }
+        .onAppear {
+            Task {
+                do {
+                    let mission = try await MissionService.fetchOneStudyMission()
+                    print("🎯 오늘의 미션 로딩 성공: \(mission)")
+                    self.todayStudyMission = mission
+                } catch {
+                    print("⚠️ 미션 로딩 실패: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    // 유효성 검사
+    private func isFormValid() -> Bool {
+        !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // 초기화
+    private func resetForm() {
+        content = ""
+        statusMessage = ""
+        showAlert = false
+    }
+
+    // 답변 제출
+    @MainActor
+    private func submitAnswer() async {
+        guard let currentDetailID: UUID = todayStudyMission?.id else {
+            statusMessage = "미션 정보가 없습니다."
+            showAlert = true
+            return
+        }
+
+        
+        guard isFormValid() else {
+            statusMessage = "답변 내용을 입력해주세요."
+            showAlert = true
+            return
+        }
+
+        isLoading = true
+        print("🚀 답변 제출 시작")
+
+        do {
+            let updateData: [String: AnyJSON] = [
+                "answer": AnyJSON.string(content.trimmingCharacters(in: .whitespacesAndNewlines)),
+                "earned_exp": AnyJSON(10),
+                "is_done": AnyJSON.bool(true)
+            ]
+
+            let response = try await SupabaseManager.shared.client
+                .from("map_user_mission_detail")
+                .update(updateData)
+                .eq("user_detail_id", value: currentDetailID)
+                .execute()
+
+            print("✅ 업데이트 성공: \(String(data: response.data, encoding: .utf8) ?? "데이터 없음")")
+
+            statusMessage = "답변이 성공적으로 제출되었습니다!"
+            showAlert = true
+            resetForm()
+
+        } catch {
+            print("❌ 제출 실패: \(error)")
+            statusMessage = "답변 제출 실패: \(error.localizedDescription)"
+            showAlert = true
+        }
+
+        isLoading = false
+    }
+}
+
+#Preview {
+    FormTextPostView(currentUserID: UUID())
+}


### PR DESCRIPTION
## 📝 설명

이 PR에서는 사용자가 제출한 Study 미션의 답변과 모범 답안을 보여주는 StudyMissionCompleteView 화면을 구현하고, Supabase에서 데이터를 조회하여 연동하는 기능을 추가했습니다.

## 🔧 주요 변경 사항

### StudyMissionCompleteView UI 구성
- **배경 및 네비게이션**: 배경 이미지와 상단 네비게이션 바 구성
- **카드 슬라이드 형식**: 모범 답안 및 나의 답변을 `ScrollView(.horizontal)` + `LazyHStack`으로 슬라이드 형식으로 표시
- **완료 상태 표시**: 답변 제출 완료 메시지 및 "메인으로" 이동 버튼 구현
- **반응형 레이아웃**: 화면 너비에 맞춰 동적으로 조정되는 카드 크기

### Supabase 연동
- **`StudyCompleteService.fetchStudyComplete`**: 
  - `map_user_mission_detail` 테이블에서 사용자의 답변(`answer`) 및 연결된 `detail_id` 조회
  - `UserAnswerInfo` 타입으로 필요한 데이터만 선택적으로 반환
- **`StudyCompleteService.fetchMissionDetail`**: 
  - `mission_details` 테이블에서 해당 미션의 `detail_answer` 조회
  - `MissionDetailModel` 타입으로 간결한 응답 구조 제공
- **에러 처리**: 오류 발생 시 `catch` 블록에서 콘솔에 로그 출력 및 graceful fallback

### 모델 정의
```swift
// 사용자 답변 정보를 위한 경량 모델
struct UserAnswerInfo: Decodable {
    let answer: String?
    let detail_id: UUID?
}

// 미션 상세 답변을 위한 경량 모델  
struct MissionDetailModel: Decodable {
    let detail_answer: String?
}

// 전체 미션 완료 정보 구조 (확장성 고려)
struct StudyCompleteModel: Identifiable, Codable, Equatable, Hashable {
    // ... 전체 필드 정의
}
```

## 🎯 구현 특징

### 데이터 흐름
1. `currentMissionID`를 통해 사용자의 특정 미션 식별
2. `map_user_mission_detail` 테이블에서 사용자 답변 및 `detail_id` 조회
3. `detail_id`를 이용해 `mission_details` 테이블에서 모범 답안 조회
4. UI에 두 답변을 나란히 표시

### 사용자 경험
- **수평 스크롤**: 모범 답안과 나의 답안을 좌우로 스와이프하여 비교 가능
- **시각적 일관성**: 동일한 카드 디자인으로 통일된 사용자 경험 제공
- **즉시 피드백**: 답변 제출 완료 상태를 명확히 표시

## 🐞 개선 사항

### 안정성 강화
- `currentMissionID`가 `nil`이거나 Supabase 쿼리 응답이 비어 있을 경우 graceful fallback 제공
- 옵셔널 체이닝을 통한 안전한 데이터 접근
- 콘솔 로그를 통해 디버깅 시 값 확인 가능 (`print("🟢", ...)` 등)

### 데이터 최적화
- 필요한 필드만 선택적으로 조회하는 경량 모델 사용
- `limit(1)`을 통한 불필요한 데이터 전송 최소화

### 확인 사항
- [ ] 모범 답안과 나의 답안이 정상적으로 표시되는지
- [ ] 수평 스크롤 동작이 자연스러운지  
- [ ] 데이터 로딩 실패 시 적절한 fallback 메시지가 표시되는지
- [ ] "메인으로" 버튼 네비게이션이 정상 동작하는지
